### PR TITLE
Safe fusebox init

### DIFF
--- a/src/fuse_box.vy
+++ b/src/fuse_box.vy
@@ -119,8 +119,16 @@ def __init__(sources: DataSource[4]):
     @notice Fuse Box Constructor
     @param sources An array of data sources to be used by the Fuse Box
     """
+    assert (
+        sources[0].active
+        or sources[1].active
+        or sources[2].active
+        or sources[3].active
+    ), "FuseBox: All data sources are inactive"
+
     self._transfer_ownership(msg.sender)
     self.fuse_box = sources
+    
 
 
 @external


### PR DESCRIPTION
Closes #31 as assertions prevent all oracles from ever being inactive, so its not possible to have inactive oracles at runtime