### PR TITLE
Bunni Oracle

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,3 @@
+[profile.default]
+evm_version = "shanghai"
+ffi = true

--- a/src/oracles/BunniOracle.t.sol
+++ b/src/oracles/BunniOracle.t.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.8.19;
 
 import "./../interfaces/IOracle.sol";
-//import "./BunniOracle.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { Test } from "forge-std/Test.sol";
 import "./../utils/VyperDeployer.sol";

--- a/src/oracles/BunniOracle.t.sol
+++ b/src/oracles/BunniOracle.t.sol
@@ -1,0 +1,301 @@
+pragma solidity 0.8.19;
+
+import "./../interfaces/IOracle.sol";
+//import "./BunniOracle.sol";
+import { Vm } from "forge-std/Vm.sol";
+import { Test } from "forge-std/Test.sol";
+import "./../utils/VyperDeployer.sol";
+
+interface IERC20 {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 value) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function approve(address spender, uint256 value) external returns (bool);
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+    function mint(address to, uint256 amount) external;
+    function decimals() external view returns (uint256);
+}
+
+interface chainlinkAggregatorV3Interface {
+  function latestRoundData() external view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+  function decimals() external view returns (uint8);
+}
+
+interface IUniswapV3Pool {
+  function swap(
+    address recipient,
+    bool zeroForOne,
+    int256 amountSpecified,
+    uint160 sqrtPriceLimitX96,
+    bytes memory data
+  ) external returns (int256 amount0, int256 amount1);
+  function token0() external view returns (address);
+  function token1() external view returns (address);
+}
+
+interface IBunniToken {
+    function pool() external view returns (IUniswapV3Pool);
+}
+
+interface IBunniOracle {
+    function bunni_key() external view returns(BunniKey memory);
+}
+
+interface IBunniLens {
+    function pricePerFullShare(BunniKey calldata key) external view returns (uint128, uint256, uint256);
+}
+
+struct BunniKey {
+    IUniswapV3Pool pool;
+    int24 tickLower;
+    int24 tickUpper;
+}
+
+contract BunniOracleTest is Test {
+  //BUNNI
+  address bunniLens = 0xb73F303472C4fD4FF3B9f59ce0F9b13E47fbfD19;
+
+  //USDC/WETH
+  IOracle usdc_weth_bunniOracle;
+  IUniswapV3Pool usdc_weth_pool;
+  address usdc_weth_bunniToken = 0x680026A1C99a1eC9878431F730706810bFac9f31; //USDC/WETH LP bunni token
+  uint256 bunni_USDC_WETH_Price;
+
+  //DAI/USDC
+  IOracle dai_usdc_bunniOracle;
+  IUniswapV3Pool dai_usdc_pool;
+  address dai_usdc_bunniToken = 0xC962Df6E0A931913B1a1D75E91299153A9D839b8; //DAI/USDC LP bunni token
+  uint256 bunni_DAI_USDC_Price;
+
+  //rETH/WETH
+  IOracle reth_weth_bunniOracle;
+  IUniswapV3Pool reth_weth_pool;
+  address reth_weth_bunniToken = 0x55Dcf951f9009425aAfE8Bfca348577451ACB433; //rETH/WETH LP bunni token
+  uint256 bunni_rETH_WETH_Price;
+  
+  //Cog Oracles
+  address usdc_oracle = address(0xa0);
+  address weth_oracle = address(0xa1);
+  address dai_oracle = address(0xa2);
+  address reth_oracle = address(0xa3);
+
+  //Chainlink Oracles
+  address chainlink_USDC_ETH_Oracle = 0x986b5E1e1755e3C2440e960477f25201B0a8bbD4;
+  address chainlink_DAI_ETH_Oracle = 0x773616E4d11A78F511299002da57A0a94577F1f4;
+  address chainlink_rETH_ETH_Oracle = 0x536218f9E9Eb48863970252233c8F271f554C2d0;
+
+  //Utils
+  IUniswapV3Pool currentPool;
+  uint160 constant UNI_V3_SLIPPAGE = 7 * 10 ** 45;
+
+  function setUp() public {
+    //fork mainnet
+    {
+      uint256 ethId = vm.createFork("https://eth.llamarpc.com");
+      vm.selectFork(ethId);
+      vm.rollFork(18422679);
+    }
+
+    //get pool addresses
+    usdc_weth_pool = IBunniToken(usdc_weth_bunniToken).pool();
+    dai_usdc_pool = IBunniToken(dai_usdc_bunniToken).pool();
+    reth_weth_pool = IBunniToken(reth_weth_bunniToken).pool();
+
+    //mock cog oracles
+    uint256 WETH_Price = 10 ** 18; //in wei
+    vm.mockCall(
+        weth_oracle,
+        abi.encodeWithSelector(IOracle.get.selector),
+        abi.encode(true, WETH_Price)
+    );
+    vm.mockCall(
+        weth_oracle,
+        abi.encodeWithSelector(IOracle.peek.selector),
+        abi.encode(true, WETH_Price)
+    );
+    vm.mockCall(
+        weth_oracle,
+        abi.encodeWithSelector(IOracle.peekSpot.selector),
+        abi.encode(WETH_Price)
+    );
+
+    (,int256 usdc_price,,,) = chainlinkAggregatorV3Interface(chainlink_USDC_ETH_Oracle).latestRoundData();
+    uint256 chainlink_USDC_Price = uint256(usdc_price); //in wei
+    vm.mockCall(
+        usdc_oracle,
+        abi.encodeWithSelector(IOracle.get.selector),
+        abi.encode(true, chainlink_USDC_Price)
+    );
+    vm.mockCall(
+        usdc_oracle,
+        abi.encodeWithSelector(IOracle.peek.selector),
+        abi.encode(true, chainlink_USDC_Price)
+    );
+    vm.mockCall(
+        usdc_oracle,
+        abi.encodeWithSelector(IOracle.peekSpot.selector),
+        abi.encode(chainlink_USDC_Price)
+    );
+
+    (,int256 dai_price,,,) = chainlinkAggregatorV3Interface(chainlink_DAI_ETH_Oracle).latestRoundData();
+    uint256 chainlink_DAI_Price = uint256(dai_price); //in wei
+    vm.mockCall(
+        dai_oracle,
+        abi.encodeWithSelector(IOracle.get.selector),
+        abi.encode(true, chainlink_DAI_Price)
+    );
+    vm.mockCall(
+        dai_oracle,
+        abi.encodeWithSelector(IOracle.peek.selector),
+        abi.encode(true, chainlink_DAI_Price)
+    );
+    vm.mockCall(
+        dai_oracle,
+        abi.encodeWithSelector(IOracle.peekSpot.selector),
+        abi.encode(chainlink_DAI_Price)
+    );
+
+    (,int256 reth_price,,,) = chainlinkAggregatorV3Interface(chainlink_rETH_ETH_Oracle).latestRoundData();
+    uint256 chainlink_rETH_Price = uint256(reth_price); //in wei
+    vm.mockCall(
+        reth_oracle,
+        abi.encodeWithSelector(IOracle.get.selector),
+        abi.encode(true, chainlink_rETH_Price)
+    );
+    vm.mockCall(
+        reth_oracle,
+        abi.encodeWithSelector(IOracle.peek.selector),
+        abi.encode(true, chainlink_rETH_Price)
+    );
+    vm.mockCall(
+        reth_oracle,
+        abi.encodeWithSelector(IOracle.peekSpot.selector),
+        abi.encode(chainlink_rETH_Price)
+    );
+
+    //deploy bunni oracles
+    {
+      VyperDeployer deployer = new VyperDeployer();
+      bytes memory usdc_weth_args  = abi.encode(bunniLens, usdc_weth_bunniToken, usdc_oracle, weth_oracle);
+      usdc_weth_bunniOracle = IOracle(deployer.deployContract("bunni_oracle", usdc_weth_args));
+
+      bytes memory dai_usdc_args  = abi.encode(bunniLens, dai_usdc_bunniToken, dai_oracle, usdc_oracle);
+      dai_usdc_bunniOracle = IOracle(deployer.deployContract("bunni_oracle", dai_usdc_args));
+
+      bytes memory reth_weth_args  = abi.encode(bunniLens, reth_weth_bunniToken, reth_oracle, weth_oracle);
+      reth_weth_bunniOracle = IOracle(deployer.deployContract("bunni_oracle", reth_weth_args));
+    }
+
+    //set bunni token prices
+    (, uint256 usdcAmountBunni1, uint256 wethAmountBunni1) = IBunniLens(bunniLens).pricePerFullShare(IBunniOracle(address(usdc_weth_bunniOracle)).bunni_key());
+    bunni_USDC_WETH_Price =
+      (usdcAmountBunni1 * chainlink_USDC_Price) / 10 ** IERC20(usdc_weth_pool.token0()).decimals()
+      +
+      (wethAmountBunni1 * WETH_Price) / 10 ** IERC20(usdc_weth_pool.token1()).decimals();
+
+    (, uint256 daiAmountBunni2, uint256 usdcAmountBunni2) = IBunniLens(bunniLens).pricePerFullShare(IBunniOracle(address(dai_usdc_bunniOracle)).bunni_key());
+    bunni_DAI_USDC_Price =
+      (daiAmountBunni2 * chainlink_DAI_Price) / 10 ** IERC20(dai_usdc_pool.token0()).decimals()
+      +
+      (usdcAmountBunni2 * chainlink_USDC_Price) / 10 ** IERC20(dai_usdc_pool.token1()).decimals();
+
+    (, uint256 rethAmountBunni3, uint256 wethAmountBunni3) = IBunniLens(bunniLens).pricePerFullShare(IBunniOracle(address(reth_weth_bunniOracle)).bunni_key());
+    bunni_rETH_WETH_Price =
+      (rethAmountBunni3 * chainlink_rETH_Price) / 10 ** IERC20(reth_weth_pool.token0()).decimals()
+      +
+      (wethAmountBunni3 * WETH_Price) / 10 ** IERC20(reth_weth_pool.token1()).decimals();
+    
+  }
+
+  function test_usdc_weth_bunniOracle() public {
+    currentPool = usdc_weth_pool;
+    (bool updated_0, uint256 price_0) = usdc_weth_bunniOracle.get();
+    //Price should be updated and match
+    assertEq(updated_0, true);
+    assertEq(price_0, bunni_USDC_WETH_Price);
+
+    (bool updated_1, uint256 price_1) = usdc_weth_bunniOracle.peek();
+    //Price should be updated and match
+    assertEq(updated_1, true);
+    assertEq(price_1, bunni_USDC_WETH_Price);
+
+    uint256 price_2 = usdc_weth_bunniOracle.peekSpot();
+    //Price should match
+    assertEq(price_2, bunni_USDC_WETH_Price);
+
+    //swap 10 eth for USDC to impact pool
+    currentPool.swap(msg.sender, false,  10 * 10**18, UNI_V3_SLIPPAGE, bytes(""));
+
+    (bool updated_3, uint256 price_3) = usdc_weth_bunniOracle.get();
+    //Price should be updated and not match
+    assertEq(updated_3, true);
+    assert(price_3 != price_0);
+  }
+
+  function test_dai_usdc_bunniOracle() public {
+    currentPool = dai_usdc_pool;
+    (bool updated_0, uint256 price_0) = dai_usdc_bunniOracle.get();
+    //Price should be updated and match
+    assertEq(updated_0, true);
+    assertEq(price_0, bunni_DAI_USDC_Price);
+
+    (bool updated_1, uint256 price_1) = dai_usdc_bunniOracle.peek();
+    //Price should be updated and match
+    assertEq(updated_1, true);
+    assertEq(price_1, bunni_DAI_USDC_Price);
+
+    uint256 price_2 = dai_usdc_bunniOracle.peekSpot();
+    //Price should match
+    assertEq(price_2, bunni_DAI_USDC_Price);
+
+    //swap 100 USDC for Dai to impact pool
+    currentPool.swap(msg.sender, false,  100 * 10**6, UNI_V3_SLIPPAGE, bytes(""));
+
+    (bool updated_3, uint256 price_3) = dai_usdc_bunniOracle.get();
+    //Price should be updated and not match
+    assertEq(updated_3, true);
+    assert(price_3 != price_0);
+  }
+
+  function test_reth_weth_bunniOracle() public {
+    currentPool = reth_weth_pool;
+    (bool updated_0, uint256 price_0) = reth_weth_bunniOracle.get();
+    //Price should be updated and match
+    assertEq(updated_0, true);
+    assertEq(price_0, bunni_rETH_WETH_Price);
+
+    (bool updated_1, uint256 price_1) = reth_weth_bunniOracle.peek();
+    //Price should be updated and match
+    assertEq(updated_1, true);
+    assertEq(price_1, bunni_rETH_WETH_Price);
+
+    uint256 price_2 = reth_weth_bunniOracle.peekSpot();
+    //Price should match
+    assertEq(price_2, bunni_rETH_WETH_Price);
+
+    //swap 10 ETH for rETH to impact pool
+    currentPool.swap(msg.sender, false,  10 * 10**18, UNI_V3_SLIPPAGE, bytes(""));
+
+    (bool updated_3, uint256 price_3) = reth_weth_bunniOracle.get();
+    //Price should be updated and not match
+    assertEq(updated_3, true);
+    assert(price_3 != price_0);
+  }
+
+  //used when swapping in UNIV3
+  function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata _data) external {
+    _data; //get rid of warning
+    if(amount0Delta > 0) {
+      deal(currentPool.token0(), address(this), uint256(amount0Delta));
+      IERC20(currentPool.token0()).transfer(msg.sender, uint256(amount0Delta));
+    }
+    if(amount1Delta > 0) {
+      deal(currentPool.token1(), address(this), uint256(amount1Delta));
+      IERC20(currentPool.token1()).transfer(msg.sender, uint256(amount1Delta));
+    }
+  }
+
+}

--- a/src/oracles/bunni_oracle.vy
+++ b/src/oracles/bunni_oracle.vy
@@ -1,0 +1,116 @@
+# @version 0.3.9
+
+# Empty IUniswapV3Pool interface
+interface IUniswapV3Pool:
+    def factory() -> address: view #Not used
+
+# BunniToken Interface
+interface IBunniToken:
+    def pool() -> IUniswapV3Pool: view
+    def tickLower() -> int24: view
+    def tickUpper() -> int24: view
+
+# BunniLens Interface
+interface IBunniLens:
+    def pricePerFullShare(key: BunniKey) -> (uint128, uint256, uint256): view
+
+# Oracle Interface
+interface IOracle:
+    def get() -> (bool, uint256): nonpayable
+    def peek() -> (bool, uint256): view
+    def peekSpot() -> uint256: view
+    def symbol() -> String[1]: view
+    def name() -> String[1]: view
+
+implements: IOracle
+
+# BunniKey struct
+struct BunniKey:
+    pool: IUniswapV3Pool
+    tickLower: int24
+    tickUpper: int24
+
+bunny_lens: public(IBunniLens)
+bunni_token: public(address)
+bunni_key: public(BunniKey)
+asset_0_oracle: public(IOracle)
+asset_1_oracle: public(IOracle)
+
+
+@external
+def __init__(_bunny_lens: address, _bunni_token: address, _asset_0_oracle: address, _asset_1_oracle: address):
+    pool: IUniswapV3Pool = IBunniToken(_bunni_token).pool()
+    tickLower: int24 = IBunniToken(_bunni_token).tickLower()
+    tickUpper: int24 = IBunniToken(_bunni_token).tickUpper()
+
+    self.bunni_key = BunniKey({pool: pool, tickLower: tickLower, tickUpper: tickUpper})
+    self.bunny_lens = IBunniLens(_bunny_lens)
+    self.bunni_token = _bunni_token
+    self.asset_0_oracle = IOracle(_asset_0_oracle)
+    self.asset_1_oracle = IOracle(_asset_1_oracle)
+
+
+@view
+@internal
+def _get_final_rate(rate_0: uint256, rate_1: uint256) -> uint256:
+    _: uint128 = 0
+    amount_0: uint256 = 0
+    amount_1: uint256 = 0
+
+    (_, amount_0, amount_1) = self.bunny_lens.pricePerFullShare(self.bunni_key)
+
+    return  amount_0 * rate_0 + amount_1 * rate_1
+
+
+@external
+def get() -> (bool, uint256):
+    success_0: bool = False
+    success_1: bool = False
+    rate_0: uint256 = 0
+    rate_1: uint256 = 0
+
+    (success_0, rate_0) = self.asset_0_oracle.get()
+    (success_1, rate_1) = self.asset_1_oracle.get()
+
+    final_rate: uint256 = self._get_final_rate(rate_0, rate_1)
+    return (success_0 and success_1, final_rate)
+
+
+@view
+@external
+def peek() -> (bool, uint256):
+    success_0: bool = False
+    success_1: bool = False
+    rate_0: uint256 = 0
+    rate_1: uint256 = 0
+
+    (success_0, rate_0) = self.asset_0_oracle.peek()
+    (success_1, rate_1) = self.asset_1_oracle.peek()
+
+    final_rate: uint256 = self._get_final_rate(rate_0, rate_1)
+    return (success_0 and success_1, final_rate)
+
+
+@view
+@external
+def peekSpot() -> uint256:
+    rate_0: uint256 = 0
+    rate_1: uint256 = 0
+
+    rate_0 = self.asset_0_oracle.peekSpot()
+    rate_1 = self.asset_1_oracle.peekSpot()
+
+    final_rate: uint256 = self._get_final_rate(rate_0, rate_1)
+    return final_rate
+
+
+@view
+@external
+def symbol() -> String[5]:
+    return "BUNNI"
+
+
+@view
+@external
+def name() -> String[5]:
+    return "Bunni"

--- a/src/oracles/bunni_oracle.vy
+++ b/src/oracles/bunni_oracle.vy
@@ -1,6 +1,6 @@
 # @version 0.3.10
 
-# Empty IUniswapV3Pool interface
+# IUniswapV3Pool interface
 interface IUniswapV3Pool:
     def token0() -> address: view
     def token1() -> address: view

--- a/src/utils/VyperDeployer.sol
+++ b/src/utils/VyperDeployer.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19;
+
+///@notice This cheat codes interface is named _CheatCodes so you can use the CheatCodes interface in other testing files without errors
+interface _CheatCodes {
+    function ffi(string[] calldata) external returns (bytes memory);
+}
+
+contract VyperDeployer {
+    address constant HEVM_ADDRESS =
+        address(bytes20(uint160(uint256(keccak256("hevm cheat code")))));
+
+    /// @notice Initializes cheat codes in order to use ffi to compile Vyper contracts
+    _CheatCodes cheatCodes = _CheatCodes(HEVM_ADDRESS);
+
+    ///@notice Compiles a Vyper contract and returns the address that the contract was deployeod to
+    ///@notice If deployment fails, an error will be thrown
+    ///@param fileName - The file name of the Vyper contract. For example, the file name for "SimpleStore.vy" is "SimpleStore"
+    ///@return deployedAddress - The address that the contract was deployed to
+
+    function deployContract(string memory fileName) public returns (address) {
+        ///@notice create a list of strings with the commands necessary to compile Vyper contracts
+        string[] memory cmds = new string[](2);
+        cmds[0] = "vyper";
+        cmds[1] = string.concat("vyper_contracts/", fileName, ".vy");
+
+        ///@notice compile the Vyper contract and return the bytecode
+        bytes memory bytecode = cheatCodes.ffi(cmds);
+
+        ///@notice deploy the bytecode with the create instruction
+        address deployedAddress;
+        assembly {
+            deployedAddress := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+
+        ///@notice check that the deployment was successful
+        require(
+            deployedAddress != address(0),
+            "VyperDeployer could not deploy contract"
+        );
+
+        ///@notice return the address that the contract was deployed to
+        return deployedAddress;
+    }
+
+    ///@notice Compiles a Vyper contract with constructor arguments and returns the address that the contract was deployeod to
+    ///@notice If deployment fails, an error will be thrown
+    ///@param fileName - The file name of the Vyper contract. For example, the file name for "SimpleStore.vy" is "SimpleStore"
+    ///@return deployedAddress - The address that the contract was deployed to
+    function deployContract(string memory fileName, bytes calldata args)
+        public
+        returns (address)
+    {
+        ///@notice create a list of strings with the commands necessary to compile Vyper contracts
+        string[] memory cmds = new string[](2);
+        cmds[0] = "vyper";
+        cmds[1] = string.concat("src/oracles/", fileName, ".vy"); //originally vyper_contracts
+
+        ///@notice compile the Vyper contract and return the bytecode
+        bytes memory _bytecode = cheatCodes.ffi(cmds);
+
+        //add args to the deployment bytecode
+        bytes memory bytecode = abi.encodePacked(_bytecode, args);
+
+        ///@notice deploy the bytecode with the create instruction
+        address deployedAddress;
+        assembly {
+            deployedAddress := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+
+        ///@notice check that the deployment was successful
+        require(
+            deployedAddress != address(0),
+            "VyperDeployer could not deploy contract"
+        );
+
+        ///@notice return the address that the contract was deployed to
+        return deployedAddress;
+    }
+
+    /// @dev Consider listening to the Blueprint if you haven't already
+    /// @param fileName - The file name of the Blueprint Contract
+    function deployBlueprint(string memory fileName) public returns (address) {
+        ///@notice create a list of strings with the commands necessary to compile Vyper contracts
+        string[] memory cmds = new string[](2);
+        cmds[0] = "vyper";
+        cmds[1] = string.concat("vyper_contracts/", fileName, ".vy");
+
+        ///@notice compile the Vyper contract and return the bytecode
+        bytes memory bytecode = cheatCodes.ffi(cmds);
+
+        require(
+            bytecode.length > 0,
+            "Initcodes length must be greater than 0"
+        );
+
+        /// @notice prepend needed items for Blueprint ERC 
+        /// See https://eips.ethereum.org/EIPS/eip-5202 for more details
+        bytes memory eip_5202_bytecode = bytes.concat(
+            hex"fe", // EIP_5202_EXECUTION_HALT_BYTE
+            hex"71", // EIP_5202_BLUEPRINT_IDENTIFIER_BYTE
+            hex"00", // EIP_5202_VERSION_BYTE
+            bytecode
+        );
+
+        bytes2 len = bytes2(uint16(eip_5202_bytecode.length));
+
+        /// @notice prepend the deploy preamble
+        bytes memory deployBytecode = bytes.concat(
+            hex"61", // DEPLOY_PREAMBLE_INITIAL_BYTE
+            len, // DEPLOY_PREAMBLE_BYTE_LENGTH
+            hex"3d81600a3d39f3", // DEPLOY_PREABLE_POST_LENGTH_BYTES
+            eip_5202_bytecode
+        );
+
+        ///@notice check that the deployment was successful
+        address deployedAddress;
+        assembly {
+            deployedAddress := create(0, add(deployBytecode, 0x20), mload(deployBytecode))
+        }
+
+        require(
+            deployedAddress != address(0),
+            "VyperDeployer could not deploy contract"
+        );
+
+        ///@notice return the address that the contract was deployed to
+        return deployedAddress;
+    }
+}


### PR DESCRIPTION
Bunni Oracle written in vyper, in order to price [Bunni](https://bunni.pro/) tokens. It functions by using two oracles that follow the Cog Finance `IOracle` interface in order to price the assets in the Uniswap V3 pool backing the bunni token.

Foundry fork tests for USDC/WETH, DAI/USDC, and rETH/WETH are included, using `VyperDeployer` in order to compile and deploy the vyper contract. These tests use Chainlink oracles as mocks for the `IOracle`. Swaps are done in the underlying UNI V3 pools to check that the bunni token price changes accordingly.

This PR addresses Oasis Issue #68.